### PR TITLE
fix: alinhamento do último botão da toolbar em viewports largas

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -48,7 +48,7 @@
                         <span class="u-hide-on-mobile">Imprimir / PDF</span>
                         <span class="u-hide-on-desktop">Gerar PDF</span>
                     </button>
-                    <button class="c-btn c-toolbar__btn u-hide-on-desktop">
+                    <button class="c-btn c-toolbar__btn">
                         <svg class="c-icon u-hide-on-desktop" viewBox="0 0 24 24">
                             <circle r="2.5" cx="5" cy="12"></circle>
                             <circle r="2.5" cx="19" cy="6"></circle>


### PR DESCRIPTION
**Related to #1**

## 📖 Descrição

Este PR corrige um desalinhamento no último botão da toolbar que ocorria em telas a partir de `387px`.

## 🔍 Causa

A classe utilitária `u-hide-on-desktop` estava aplicada incorrectamente no **próprio elemento do botão**. Isso interferia nas propriedades `display: flex` e `flex-direction: column`, impedindo o posicionamento vertical esperado entre o ícone e o texto em resoluções intermediárias (telas acima de `387px`).

## 💡Solução

- Removida a classe `u-hide-on-desktop` do **botão**.
- A classe foi mantida exclusivamente no ícone `svg` interno, garantindo que apenas o ícone seja ocultado no desktop, preservando o comportamento de layout do botão em todas as resoluções.

## 🧪 Como Testar

1. Redimensione a viewport para `387px` ou superior.
2. Verifique se o conteúdo do último botão da toolbar está alinhado verticalmente (ícone acima do texto).
3. Confirme se o ícone desaparece correctamente no breakpoint de desktop (1024px).