### PR TITLE
fix: correção da escala activa da toolbar de 96 para 0.96

### DIFF
--- a/src/scss/components/_c-button.scss
+++ b/src/scss/components/_c-button.scss
@@ -17,10 +17,10 @@
     }
 
     &:active {
-        @include cannot-hover {
-            transform: scale(96);
-        }
         opacity: 0.7;
+        @include cannot-hover {
+            transform: scale(0.96);
+        }
     }
 
     &--primary {    


### PR DESCRIPTION
**Related to #1**

## 📝 Descrição

Corrige um erro de dactilografia no CSS da toolbar onde o valor de `scale` estava definido como `96` em vez de `0.96`. Esta falha afetava **todos os botões da toolbar** e era particularmente crítica em **ecrãs pequenos (mobile)**, fazendo com que qualquer botão pressionado expandisse descontroladamente, cobrindo a interface.

## 🛠 Alterações Técnicas

Ajustado o valor global de `transform: scale()` de `96` para `0.96` para a classe base dos botões da toolbar.

## 🧪 Como Testar

1. **Abra** a aplicação num emulador mobile ou redimensione o browser para um ecrã pequeno.
2. **Toque** em cada um dos botões da toolbar para testar o estado `:active`.
3. **Valide** se todos os botões agora apresentam o efeito de clique correto (redução suave) em vez de expandirem.