### PR TITLE
fix: ajuste do alinhamento do menu hambúrguer no cabeçalho

### DIFF
--- a/src/scss/components/_eden-c-header.scss
+++ b/src/scss/components/_eden-c-header.scss
@@ -18,7 +18,7 @@
         padding-block: var(--eden-sys-space-xs);
     }
 
-    &__hamburger {
+    .eden-c-hamburger {
         margin-inline-start: var(--_hamburger-alignment-offset);
     }
 


### PR DESCRIPTION
**Related to #1**

## 📝 Descrição

#fix: Correção do alinhamento do ícone de menu hambúrguer no cabeçalho. A classe anteriormente referenciada no CSS (`.eden-c-header__hamburguer`) não existia no HTML, impedindo a aplicação das propriedades de posicionamento.

## 🛠️ Alterações Técnicas

- Substituição da classe órfã pelo seletor descendente `.c-header .c-hamburger`.
- Restauro do alinhamento (margem negativa) para garantir a paridade com o design.
- Limpeza de seletores CSS obsoletos no componente de Header.

## 🧪 Como Testar

1. Aceder à aplicação em qualquer resolução.
2. Verificar se o ícone do hambúrguer está correctamente alinhado à esquerda (sem o recuo indesejado).
3. Inspecionar o elemento para garantir que o novo seletor está a aplicar os estilos correctamente.