### PR TITLE
fix: vulnerabilidades de segurança (npm audit)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3318,9 +3318,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -5135,9 +5135,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5257,9 +5257,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5269,7 +5269,7 @@
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo.js"


### PR DESCRIPTION
**Related to #1**

## 🔍 Causa

Vulnerabilidades de segurança identificadas através do alerta automático do `npm audit`.

## 💡 Solução

Execução do comando `npm audit fix` para actualização das bibliotecas afetadas para versões seguras:
- **immutable**: `5.1.4` -> `5.1.5`
- **sax**: `1.4.4` -> `1.5.0`
- **svgo**: `4.0.0` -> `4.0.1`

## 🚀 Benefícios
- Correção de vulnerabilidades para garantia de segurança do **App-shell**.
- Minimização de bugs potenciais em dependências de terceiros.

## 🧪 Como testar?

1. `npm install`
2. Executar `npm run build` e verificar se não há alertas no terminal.