### PR TITLE
fix: ajuste de altura do ecrã (SVH) para visibilidade do rodapé no mobile

### DIFF
--- a/src/scss/layout/_eden-layout.scss
+++ b/src/scss/layout/_eden-layout.scss
@@ -11,6 +11,7 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    min-height: 100svh;
     
     @include desktop {
         display: grid;


### PR DESCRIPTION
# 🔍 Causa

O rodapé (footer) da aplicação ficava parcialmente oculto ou cortado em navegadores móveis. Isto ocorria porque a unidade `100vh` não contabiliza o espaço ocupado pela barra de endereços dinâmica do navegador, empurrando o conteúdo para fora da área visível.

# 💡 Solução

* Uso de `100svh` (Small Viewport Height) no body para garantir o ajuste perfeito à área visível real do telemóvel.
* **Compatibilidade:** Preservação de `min-height: 100vh` como fallback para navegadores legados.

# 🚀 Benefícios

* **Visibilidade Total:** Garantia de que o rodapé e os créditos ("© 2026 Adérito Quinamine") estão sempre visíveis ao carregar a página.
* **UX Mobile:** Eliminação do scroll desnecessário para visualizar informações de suporte e termos.
* **Código Limpo:** Redução da profundidade do DOM e melhor aproveitamento da semântica do CSS.

# 🧪 Como testar?

1. Abrir a aplicação num navegador móvel (Chrome ou Safari).
2. Confirmar se o rodapé está encostado ao fundo do ecrã sem ser cortado pela interface do browser.
3. Verificar a estabilidade do layout no desktop ao redimensionar a janela.